### PR TITLE
usage of Destination API

### DIFF
--- a/01-source_service/020-k8s-events.yaml
+++ b/01-source_service/020-k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: service-one
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: service-one

--- a/02-source_channel/020-k8s-events.yaml
+++ b/02-source_channel/020-k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: InMemoryChannel
-    name: testchannel
+    ref:
+      apiVersion: messaging.knative.dev/v1alpha1
+      kind: InMemoryChannel
+      name: testchannel

--- a/03-source_broker/020-k8s-events.yaml
+++ b/03-source_broker/020-k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: default
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default

--- a/04_kafka_source_channel/020-k8s-events.yaml
+++ b/04_kafka_source_channel/020-k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: KafkaChannel
-    name: kafka-channel-one
+    ref:
+      apiVersion: messaging.knative.dev/v1alpha1
+      kind: KafkaChannel
+      name: kafka-channel-one

--- a/05_kafka_default_channel/020-k8s-events.yaml
+++ b/05_kafka_default_channel/020-k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: default
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default


### PR DESCRIPTION
with the Advend of Knative Eventing 0.10.0 Sources are now using the destination API, and changes on the sink are like:

```
ref:
  apiVersion:...
  kind: ..
  name: ..
```

the OLD API is still around, but deprecated .... 